### PR TITLE
Bump nokogiri version

### DIFF
--- a/jekyll-wikilinks.gemspec
+++ b/jekyll-wikilinks.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   spec.add_dependency "jekyll", "~> 4.2.0"
-  spec.add_dependency "nokogiri", "~> 1.12.3"
+  spec.add_dependency "nokogiri", "~> 1.13.2"
 
   # For more information and examples about making a new gem, checkout our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
Saw a warning from dependabot in my repository when I included this dependency to my project that nokogiri was vulnerable to some CVEs. 

```
Those library versions address the following upstream CVEs:

    libxslt: CVE-2021-30560 (CVSS 8.8, High severity)
    libxml2: CVE-2022-23308 (Unspecified severity, see more information below)
```

This version is the minimum version that applies the patch for those CVEs.